### PR TITLE
fix bug when set lease, no need base64 encode

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -132,7 +132,6 @@ class Client
         ];
 
         $params = $this->encode($params);
-//        $options = $this->encode($options);
         $body = $this->request(self::URI_PUT, $params, $options);
         $body = $this->decodeBodyForFields(
             $body,

--- a/src/Client.php
+++ b/src/Client.php
@@ -132,7 +132,7 @@ class Client
         ];
 
         $params = $this->encode($params);
-        $options = $this->encode($options);
+//        $options = $this->encode($options);
         $body = $this->request(self::URI_PUT, $params, $options);
         $body = $this->decodeBodyForFields(
             $body,


### PR DESCRIPTION
encode $option['lease'] will lead to '{"error":"invalid character 'N' looking for beginning of value","code":3}'